### PR TITLE
IE9 issue with preventDefault() causing js error in some situations

### DIFF
--- a/synthetic.js
+++ b/synthetic.js
@@ -455,7 +455,7 @@ steal.then(function(){
 				event.preventDefault = function() {
 					prevents++;
 					if (++prevents > 0 ) {
-						preventDefault.apply(this, []);
+						preventDefault.apply(event, []);
 					}
 				};
 				element.dispatchEvent(event);


### PR DESCRIPTION
fixes issue in IE9 where 'this' was referring to the global object rather than the event in question

http://forum.javascriptmvc.com/#Topic/32525000000590823
