### PR TITLE
Allow Syn.type to take non-strings.

### DIFF
--- a/key.js
+++ b/key.js
@@ -728,7 +728,7 @@ steal('./synthetic','./browsers.js',function(Syn) {
 		 * @codeend
 		 * For each character, a keydown, keypress, and keyup is triggered if
 		 * appropriate.
-		 * @param {String} options
+		 * @param {String|Number} options
 		 * @param {HTMLElement} [element]
 		 * @param {Function} [callback]
 		 * @return {HTMLElement} the element currently focused.
@@ -831,7 +831,7 @@ steal('./synthetic','./browsers.js',function(Syn) {
 		_type: function( options, element, callback ) {
 			//break it up into parts ...
 			//go through each type and run
-			var parts = options.match(/(\[[^\]]+\])|([^\[])/g),
+			var parts = (options+"").match(/(\[[^\]]+\])|([^\[])/g),
 				self = this,
 				runNextPart = function( runDefaults, el ) {
 					var part = parts.shift();

--- a/test/qunit/key_test.js
+++ b/test/qunit/key_test.js
@@ -438,4 +438,12 @@ test("focus moves on keydown to another element", function(){
 	Syn.type("a", 'key' , function(){
 	});
 })
+
+test("typing in a number works", function() {
+  stop();
+  Syn.type(9999, 'key', function() {
+    equal( st.g('key').value, "9999", "typing in numbers works" );
+    start();
+  });
+});
 })


### PR DESCRIPTION
Now anything that can be toString-ed can be passed as the option for Syn.type. Mostly just for Number.
