### PR TITLE
Syn.support.linkHrefJS is always false

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -212,6 +212,7 @@ steal('src/synthetic.js',function(Syn) {
 		window.__synthTest = function() {
 			Syn.support.linkHrefJS = true;
 		}
+
 		var div = document.createElement("div"),
 			checkbox, submit, form, input, select;
 
@@ -221,6 +222,9 @@ steal('src/synthetic.js',function(Syn) {
 		checkbox = form.childNodes[0];
 		submit = form.childNodes[2];
 		select = form.getElementsByTagName('select')[0]
+
+		//trigger click for linkHrefJS support, childNodes[6] === anchor
+		Syn.trigger('click', {}, form.childNodes[6]);
 
 		checkbox.checked = false;
 		checkbox.onchange = function() {

--- a/test/qunit/mouse_test.js
+++ b/test/qunit/mouse_test.js
@@ -1,8 +1,8 @@
-steal("src/synthetic.js", function(Syn){	
-	var didSomething = false;
-	window.doSomething = function(){
-		didSomething = true;
-	}
+steal("src/synthetic.js", function(Syn) {
+	var didSomething = 0;
+	window.doSomething = function() {
+		++didSomething;
+	};
 
 module("synthetic/mouse",{
 	setup: function() {
@@ -12,14 +12,17 @@ module("synthetic/mouse",{
 			"<input type='radio' name='radio' value='radio2' id='radio2'/>"+
 			"<a href='javascript:doSomething()' id='jsHref'>click me</a>"+
 			"<a href='#aHash' id='jsHrefHash'>click me</a>"+
-			"<input type='submit' id='submit'/></div></form>"
-			
+			"<input type='submit' id='submit'/></div></form>";
+	},
+
+	teardown: function() {
+		didSomething = 0;
 	}
 })
 
 test("Syn basics", function(){
 
-        ok(Syn,"Syn exists")
+		ok(Syn,"Syn exists")
 		
 		st.g("qunit-test-area").innerHTML = "<div id='outer'><div id='inner'></div></div>"
 		var mouseover = 0, mouseoverf = function(){
@@ -220,12 +223,10 @@ test("Click! Event Order", Syn.skipFocusTests? 3: 4, function(){
 	
 })
 
-test("Click Anchor Runs HREF JavaScript", function(){
-
-	Syn.trigger("click",{},st.g("jsHref"))
-	
-	ok( didSomething, "link href JS run" );
-})
+test("Click Anchor Runs HREF JavaScript", function() {
+	Syn.trigger("click", {}, st.g("jsHref"));
+	equal(didSomething, 1, "link href JS run");
+});
 
 test("Click! Anchor has href", function(){
 	stop();
@@ -421,7 +422,7 @@ test("focus on an element then another in another page", function(){
 	});
 	iframe.src = page1
 	st.g("qunit-test-area").appendChild(iframe);
-})
+});
 
 
 })


### PR DESCRIPTION
Syn.support.linkHrefJS is always false, therefore the javascript in an anchor tags href attribute is executed twice. Once when the event is dispatched and then again because Syn manually evals the javascript.

The root cause seems to be that the feature test is never executed. The anchor tag synlink should be clicked on, but isn't in `mouse.js`:

```
<a href='javascript:__synthTest()' id='synlink'></a>
```
