### PR TITLE
Duplicate member in object definition

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -142,6 +142,12 @@ steal('src/synthetic.js','src/browsers.js',function(Syn) {
 		 * escape    - escape button
 		 * num-lock  - allows numbers on keypad
 		 * print     - screen capture
+		 * subtract  - subtract (keypad) -
+		 * dash      - dash -
+		 * divide    - divide (keypad) /
+		 * forward-slash - forward slash /
+		 * decimal   - decimal (keypad) .
+		 * period    - period .
 		 * @codeend
 		 */
 		keycodes: {
@@ -230,15 +236,18 @@ steal('src/synthetic.js','src/browsers.js',function(Syn) {
 			'num9': 105,
 			'*': 106,
 			'+': 107,
-			'-': 109,
-			'.': 110,
+			'subtract': 109,
+			'decimal': 110,
 			//normal-characters, others
-			'/': 111,
+			'divide': 111,
 			';': 186,
 			'=': 187,
 			',': 188,
+			'dash': 189,
 			'-': 189,
+			'period': 190,
 			'.': 190,
+			'forward-slash': 191,
 			'/': 191,
 			'`': 192,
 			'[': 219,

--- a/test/qunit/key_test.js
+++ b/test/qunit/key_test.js
@@ -435,6 +435,41 @@ test("number key codes", 2, function(){
 	});
 })
 
+test("Key codes of like-keys", function(){
+	stop();
+
+	var keys = {
+		"subtract": 109,
+		"dash": 189,
+		"divide": 111,
+		"forward-slash": 191,
+		"decimal": 110,
+		"period": 190
+	};
+
+	var cnt = 0;
+	var done = function(){
+		cnt++;
+		if(cnt === 6) {
+			start();
+		}
+	};
+
+	var testKeyCode = function(key, code){
+		st.binder("key", "keydown", function f(ev){
+			st.unbinder("key", "keydown", f);
+			ok(ev.keyCode === code);
+			ok(ev.which === ev.keyCode);
+			done();
+		});
+		Syn.type("[" + key + "]", "key");
+	};
+
+	for(var key in keys) {
+		testKeyCode(key, keys[key]);
+	}
+});
+
 test("focus moves on keydown to another element", function(){
 	stop();
 	st.binder("key","keydown",function(ev){


### PR DESCRIPTION
If you try to lint [key.js](https://github.com/jupiterjs/syn/blob/master/key.js) you get the following errors

[line 222](https://github.com/jupiterjs/syn/blob/master/key.js#L222), Duplicate member '-'.
[line 223](https://github.com/jupiterjs/syn/blob/master/key.js#L223), Duplicate member '.'.
[line 224](https://github.com/jupiterjs/syn/blob/master/key.js#L224), Duplicate member '/'.

I guess only the second declaration of those symbols is needed.
