### PR TITLE
Prevents createChange from leaking to global

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -11,7 +11,7 @@ steal('src/synthetic.js',function(Syn) {
 		},
 		click: function() {
 			// prevents the access denied issue in IE if the click causes the element to be destroyed
-			var element = this, href, type, radioChanged, nodeName, scope;
+			var element = this, href, type, createChange, radioChanged, nodeName, scope;
 			try {
 				href = element.href;
 				type = element.type;


### PR DESCRIPTION
The variable createChange was leaking up to global scope because it was
not declared.
