### PR TITLE
__synthTest() fails in Firefox

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -208,15 +208,14 @@ steal('src/synthetic.js',function(Syn) {
 			setTimeout(arguments.callee, 1)
 			return;
 		}
-		var oldSynth = window.__synthTest;
-		window.__synthTest = function() {
+		Syn.support.linkHrefJSTest = function() {
 			Syn.support.linkHrefJS = true;
 		}
 
 		var div = document.createElement("div"),
 			checkbox, submit, form, input, select;
 
-		div.innerHTML = "<form id='outer'>" + "<input name='checkbox' type='checkbox'/>" + "<input name='radio' type='radio' />" + "<input type='submit' name='submitter'/>" + "<input type='input' name='inputter'/>" + "<input name='one'>" + "<input name='two'/>" + "<a href='javascript:__synthTest()' id='synlink'></a>" + "<select><option></option></select>" + "</form>";
+		div.innerHTML = "<form id='outer'>" + "<input name='checkbox' type='checkbox'/>" + "<input name='radio' type='radio' />" + "<input type='submit' name='submitter'/>" + "<input type='input' name='inputter'/>" + "<input name='one'>" + "<input name='two'/>" + "<a href='javascript:Syn.support.linkHrefJSTest()' id='synlink'></a>" + "<select><option></option></select>" + "</form>";
 		document.documentElement.appendChild(div);
 		form = div.firstChild
 		checkbox = form.childNodes[0];
@@ -283,7 +282,6 @@ steal('src/synthetic.js',function(Syn) {
 		document.documentElement.removeChild(div);
 
 		//check stuff
-		window.__synthTest = oldSynth;
 		Syn.support.ready++;
 	})();
 	return Syn;


### PR DESCRIPTION
In Firefox 27.0.1 (latest stable), the linkHrefJS test fails with a warning that __synthTest is not a function.

This seems to happen because by the time the link click is simulated, the function has been overwritten with the original __synthTest function (which defaults to undefined).

Wrapping the window.__synthTest = oldSynth in a function seems to address this issue.
