### PR TITLE
Loading the syn.js library causes Firefox to change the page position

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -885,6 +885,10 @@ steal('src/synthetic.js', 'src/typeable.js', 'src/browsers.js',function(Syn) {
 				return;
 			}
 
+            // Store the current state before making any changes to focus.
+            var startPos = [ window.scrollX, window.scrollY ],
+                startNode = window.document.activeElement;
+
 			var div = document.createElement("div"),
 				checkbox, submit, form, input, submitted = false,
 				anchor, textarea, inputter, one;
@@ -954,6 +958,11 @@ steal('src/synthetic.js', 'src/typeable.js', 'src/browsers.js',function(Syn) {
 			Syn.support.oninput = 'oninput' in one;
 			
 			document.documentElement.removeChild(div);
+            // Return element focus and scroll position to it's position at the start of the function.
+            if (startNode) {
+                startNode.focus();
+            }
+            window.scrollTo(startPos[0], startPos[1]);
 
 			Syn.support.ready++;
 		}();


### PR DESCRIPTION
We've noticed that when including the syn.js file, the page position changes. In our case, this has the effect of failing some of our behat tests because it is no longer possible to interact with some Nodes if the page overflow has been disabled.

The library should not have an effect on page position in this way.

This seems to be caused by src/key.js at the point that it focuses on the input field. The comment above this is:

```
// Firefox 4 won't write key events if the element isn't focused
```

Considering Firefox doesn't seem to trigger these key events anyway, I feel that this should be removed.
