### PR TITLE
Use correct URL for GitHub Raw files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ dragging exactly how a real user would perform those actions.
 
 ## Using Syn
 
-You'd use syn to perform functional testing or simulate user actions on a JavaScript application. To add syn to your page all you need to do is add [syn.js](https://raw.github.com/bitovi/syn/master/dist/syn.js) to your page. Syn is also available via Bower:
+You'd use syn to perform functional testing or simulate user actions on a JavaScript application. To add syn to your page all you need to do is add [syn.js](https://rawgithub.com/bitovi/syn/master/dist/syn.js) to your page. Syn is also available via Bower:
 
     bower install syn
 


### PR DESCRIPTION
This change enables the right `content-type` as refered here: http://rawgit.com/

This will enable also to make jsFiddle (and others) use of the raw file like http://jsfiddle.net/aSB93/
