### PR TITLE
Make syn installable through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "Syn",
+  "name": "syn-events",
+  "version": "0.0.2",
   "author": {
     "name": "Bitovi",
     "email": "contact@bitovi.com",
@@ -29,7 +30,6 @@
 		"grunt-jsbeautifier": "^0.2.6"
   },
   "scripts": {
-    "test": "grunt test",
-    "postinstall": "node_modules/bower/bin/bower install"
+    "test": "grunt test"
   }
 }


### PR DESCRIPTION
- The bower postinstall creates a bower requirement that is not needed
  to use syn
- A version is required by npm
  "The most important things in your package.json are the name and
  version fields. Those are actually required, and your package won't
  install without them."
  https://www.npmjs.org/doc/json.html
- The name "syn" is already taken, changed it to "syn-events". npm does
  not allow upper case letters in the package name
