### PR TITLE
Change API to take element as first argument

### DIFF
--- a/dist/test.html
+++ b/dist/test.html
@@ -5,10 +5,10 @@
 		<script src="syn.js"></script>
 		<script type="text/javascript">
 			document.getElementById('click').onclick = function() {
-				console.log('clicked')
-			}
+				console.log('clicked');
+			};
 
-			Syn.click({},'click')
+			Syn.click('click', {});
 		</script>
 	</body>
 </html>

--- a/src/drag/drag.html
+++ b/src/drag/drag.html
@@ -21,12 +21,12 @@
 <script type='text/javascript' id="demo-source">
 	steal('funcunit/synthetic', 'funcunit/synthetic/drag','jquery').then(function(){
 		setTimeout(function(){
-			Syn("move",{
+			Syn("move", "start", {
 				from: "#start",
 				to: "#end",
 				duration: 1000
-			},"start")
-		},1000)
+			});
+		},1000);
 		
 		
 		$(".over").bind('mouseover',function(){

--- a/src/drag/drag.js
+++ b/src/drag/drag.js
@@ -55,7 +55,7 @@ steal('../synthetic.js', function (Syn) {
 		//creates an event at a certain point
 		createEventAtPoint = function (event, point, element) {
 			var el = elementFromPoint(point, element);
-			Syn.trigger(event, point, el || element);
+			Syn.trigger(el || element, event, point);
 			return el;
 		},
 		// creates a mousemove event, but first triggering mouseout / mouseover if appropriate
@@ -64,12 +64,12 @@ steal('../synthetic.js', function (Syn) {
 			if (last !== el && el && last) {
 				var options = Syn.helpers.extend({}, point);
 				options.relatedTarget = el;
-				Syn.trigger("mouseout", options, last);
+				Syn.trigger(last, "mouseout", options);
 				options.relatedTarget = last;
-				Syn.trigger("mouseover", options, el);
+				Syn.trigger(el, "mouseover", options);
 			}
 
-			Syn.trigger("mousemove", point, el || element);
+			Syn.trigger(el || element, "mousemove", point);
 			return el;
 		},
 		// start and end are in clientX, clientY
@@ -203,7 +203,7 @@ steal('../synthetic.js', function (Syn) {
 		/**
 			 * @function Syn.move move()
 		   * @parent mouse
-			 * @signature `Syn.move(options, from, callback)`
+			 * @signature `Syn.move(from, options, callback)`
 			 * Moves the cursor from one point to another.  
 			 * 
 			 * ### Quick Example
@@ -212,12 +212,12 @@ steal('../synthetic.js', function (Syn) {
 			 * the window to (100,100) in 1 second.
 			 * 
 			 *     Syn.move(
+			 *          document.document,
 			 *          {
 			 *            from: {clientX: 0, clientY: 0},
 			 *            to: {clientX: 100, clientY: 100},
 			 *            duration: 1000
-			 *          },
-			 *          document.document)
+			 *          })
 			 * 
 			 * ## Options
 			 * 
@@ -229,22 +229,22 @@ steal('../synthetic.js', function (Syn) {
 			 * to client coordinates.
 			 * 
 			 *     Syn.move(
+			 *          document.document,
 			 *          {
 			 *            from: {pageX: 0, pageY: 0},
 			 *            to: {pageX: 100, pageY: 100}
-			 *          },
-			 *          document.document)
+			 *          })
 			 * 
 			 * ### String Coordinates
 			 * 
 			 * You can set the pageX and pageY as strings like:
 			 * 
 			 *     Syn.move(
+			 *          document.document,
 			 *          {
 			 *            from: "0x0",
 			 *            to: "100x100"
-			 *          },
-			 *          document.document)
+			 *          })
 			 * 
 			 * ### Element Coordinates
 			 * 
@@ -252,42 +252,42 @@ steal('../synthetic.js', function (Syn) {
 			 * and the coordinate will be set as the center of the element.
 			 
 			 *     Syn.move(
+			 *          document.document,
 			 *          {
 			 *            from: $(".recipe")[0],
 			 *            to: $("#trash")[0]
-			 *          },
-			 *          document.document)
+			 *          })
 			 * 
 			 * ### Query Strings
 			 * 
 			 * If jQuery is present, you can pass a query string as the from or to option.
 			 * 
 			 * Syn.move(
+			 *      document.document,
 			 *      {
 			 *        from: ".recipe",
 			 *        to: "#trash"
-			 *      },
-			 *      document.document)
+			 *      })
 			 *    
 			 * ### No From
 			 * 
 			 * If you don't provide a from, the element argument passed to Syn is used.
 			 * 
 			 *     Syn.move(
-			 *          { to: "#trash" },
-			 *          'myrecipe')
+			 *          'myrecipe',
+			 *          { to: "#trash" })
 			 * 
 			 * ### Relative
 			 * 
 			 * You can move the drag relative to the center of the from element.
 			 * 
-			 *     Syn.move("+20 +30", "myrecipe");
-			 * 
-			 * @param {Object} options options to configure the drag
+			 *     Syn.move("myrecipe", "+20 +30");
+			 *
 			 * @param {HTMLElement} from the element to move
+			 * @param {Object} options options to configure the drag
 			 * @param {Function} callback a callback that happens after the drag motion has completed
 			 */
-		_move: function (options, from, callback) {
+		_move: function (from, options, callback) {
 			//need to convert if elements
 			var win = Syn.helpers.getWindow(from),
 				fro = convertOption(options.from || from, win, from),
@@ -302,15 +302,15 @@ steal('../synthetic.js', function (Syn) {
 		/**
 		 * @function Syn.drag drag()
 		 * @parent mouse
-		 * @signature `Syn.drag(options, from, callback)`
+		 * @signature `Syn.drag(from, options, callback)`
 		 * Creates a mousedown and drags from one point to another.
 		 * Check out [Syn.prototype.move move] for API details.
 		 *
+		 * @param {HTMLElement} from
 		 * @param {Object} options
-		 * @param {Object} from
 		 * @param {Object} callback
 		 */
-		_drag: function (options, from, callback) {
+		_drag: function (from, options, callback) {
 			//need to convert if elements
 			var win = Syn.helpers.getWindow(from),
 				fro = convertOption(options.from || from, win, from),

--- a/src/drag/test/qunit/drag_test.js
+++ b/src/drag/test/qunit/drag_test.js
@@ -34,7 +34,7 @@ steal("src/synthetic.js", function (Syn) {
 	// 	
 	// stop();
 	// 	
-	// Syn.drag( {to: "#drop", duration: 700}, $("#drag")[0], function(){
+	// Syn.drag($("#drag")[0], {to: "#drop", duration: 700}, function(){
 	// ok(drops.dropover,"dropover fired correctly")
 	// $("#qunit-test-area").innerHTML = "";
 	// start();
@@ -105,7 +105,7 @@ steal("src/synthetic.js", function (Syn) {
 			.bind('mousemove', move);
 
 		stop();
-		Syn.move({
+		Syn.move("wrap", {
 			from: {
 				pageX: 2,
 				pageY: 50
@@ -115,7 +115,7 @@ steal("src/synthetic.js", function (Syn) {
 				pageY: 50
 			},
 			duration: 1000
-		}, "wrap", function () {
+		}, function () {
 
 			equal(clientX, 199);
 			equal(clientY, 50);
@@ -195,7 +195,7 @@ steal("src/synthetic.js", function (Syn) {
 
 	// 	stop();
 
-	// 	Syn.drag( {to: "#midpoint", duration: 700}, $("#drag")[0], function(){
+	// 	Syn.drag($("#drag")[0], {to: "#midpoint", duration: 700}, function(){
 
 	// 		ok(drags.draginit, "draginit fired correctly")
 	// 		ok(drags.dragmove, "dragmove fired correctly")
@@ -205,13 +205,13 @@ steal("src/synthetic.js", function (Syn) {
 	// 		ok(!drops.dropon,	"dropon not fired yet")
 	// 		ok(drops.dropend, 	"dropend fired");
 
-	// 		Syn.drag( {to: "#drop", duration: 700}, $("#drag")[0], function(){
+	// 		Syn.drag($("#drag")[0], {to: "#drop", duration: 700}, function(){
 	// 			ok(drops.dropinit, 	"dropinit fired correctly")
 	// 			ok(drops.dropover, 	"dropover fired correctly")
 	// 			ok(drops.dropmove, 	"dropmove fired correctly")
 	// 			ok(drops.dropon, 	"dropon fired correctly")
 
-	// 			Syn.drag( {to: "#midpoint", duration: 700}, $("#drag")[0], function(){
+	// 			Syn.drag($("#drag")[0], {to: "#midpoint", duration: 700}, function(){
 	// 				ok(drags.dragout, 	"dragout fired correctly")
 	// 				ok(drops.dropout, 	"dropout fired correctly")
 	// 				$("#qunit-test-area").innerHTML = "";

--- a/src/key.js
+++ b/src/key.js
@@ -117,11 +117,11 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		 * A list of the keys and their keycodes codes you can type.
 		 * You can add type keys with
 		 * @codestart
-		 * Syn('key','delete','title');
+		 * Syn('key', 'title', 'delete');
 		 *
 		 * //or
 		 *
-		 * Syn('type','One Two Three[left][left][delete]','title')
+		 * Syn('type', 'title', 'One Two Three[left][left][delete]');
 		 * @codeend
 		 *
 		 * The following are a list of keys you can type:
@@ -525,13 +525,13 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 				var nodeName = this.nodeName.toLowerCase();
 				// submit a form
 				if (nodeName === 'input') {
-					Syn.trigger("change", {}, this);
+					Syn.trigger(this, "change", {});
 				}
 
 				if (!Syn.support.keypressSubmits && nodeName === 'input') {
 					var form = Syn.closest(this, "form");
 					if (form) {
-						Syn.trigger("submit", {}, form);
+						Syn.trigger(form, "submit", {});
 					}
 
 				}
@@ -542,7 +542,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 				}
 				// 'click' hyperlinks
 				if (!Syn.support.keypressOnAnchorClicks && nodeName === 'a') {
-					Syn.trigger("click", {}, this);
+					Syn.trigger(this, "click", {});
 				}
 			},
 			// 
@@ -744,7 +744,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		/**
 		 * @function Syn.key key()
 		 * @parent keys
-		 * @signature `Syn.key(options, element, callback)`
+		 * @signature `Syn.key(element, options, callback)`
 		 * Types a single key.  The key should be
 		 * a string that matches a
 		 * [Syn.static.keycodes].
@@ -752,20 +752,20 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		 * The following sends a carridge return
 		 * to the 'name' element.
 		 * @codestart
-		 * Syn.key('\r','name')
+		 * Syn.key('name', '\r')
 		 * @codeend
 		 * For each character, a keydown, keypress, and keyup is triggered if
 		 * appropriate.
-		 * @param {String|Number} options
 		 * @param {HTMLElement} [element]
+		 * @param {String|Number} options
 		 * @param {Function} [callback]
 		 * @return {HTMLElement} the element currently focused.
 		 */
-		_key: function (options, element, callback) {
+		_key: function (element, options, callback) {
 			//first check if it is a special up
 			if (/-up$/.test(options) && h.inArray(options.replace("-up", ""),
 				Syn.key.kinds.special) !== -1) {
-				Syn.trigger('keyup', options.replace("-up", ""), element);
+				Syn.trigger(element, 'keyup', options.replace("-up", ""));
 				return callback(true, element);
 			}
 
@@ -775,7 +775,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 				caret = Syn.typeable.test(element) && getSelection(element),
 				key = convert[options] || options,
 				// should we run default events
-				runDefaults = Syn.trigger('keydown', key, element),
+				runDefaults = Syn.trigger(element, 'keydown', key),
 
 				// a function that gets the default behavior for a key
 				getDefault = Syn.key.getDefault,
@@ -803,7 +803,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 							.document.activeElement;
 					}
 
-					runDefaults = Syn.trigger('keypress', keypressOptions, element);
+					runDefaults = Syn.trigger(element, 'keypress', keypressOptions);
 					if (runDefaults) {
 						defaultResult = getDefault(key)
 							.call(element, keypressOptions, h.getWindow(element),
@@ -820,7 +820,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 							.document.activeElement;
 					}
 
-					Syn.trigger('keypress', keypressOptions, element);
+					Syn.trigger(element, 'keypress', keypressOptions);
 				}
 			}
 			if (defaultResult && defaultResult.nodeName) {
@@ -830,9 +830,9 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 			if (defaultResult !== null) {
 				Syn.schedule(function () {
 					if (Syn.support.oninput) {
-						Syn.trigger('input', Syn.key.options(key, 'input'), element);
+						Syn.trigger(element, 'input', Syn.key.options(key, 'input'));
 					}
-					Syn.trigger('keyup', Syn.key.options(key, 'keyup'), element);
+					Syn.trigger(element, 'keyup', Syn.key.options(key, 'keyup'));
 					callback(runDefaults, element);
 				}, 1);
 			} else {
@@ -847,7 +847,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		/**
 		 * @function Syn.type type()
 		 * @parent keys
-		 * @signature `Syn.type(options, element, callback)`
+		 * @signature `Syn.type(element, options, callback)`
 		 * Types sequence of [Syn.key key actions].  Each
 		 * character is typed, one at a type.
 		 * Multi-character keys like 'left' should be
@@ -855,7 +855,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		 *
 		 * The following types 'JavaScript MVC' then deletes the space.
 		 * @codestart
-		 * Syn.type('JavaScript MVC[left][left][left]\b','name')
+		 * Syn.type('name', 'JavaScript MVC[left][left][left]\b')
 		 * @codeend
 		 *
 		 * Type is able to handle (and move with) tabs (\t).
@@ -864,11 +864,11 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 		 * @codestart
 		 * Syn.type("Justin\tMeyer\t27\tjustinbmeyer@gmail.com\r")
 		 * @codeend
-		 * @param {String} options the text to type
 		 * @param {HTMLElement} [element] an element or an id of an element
+		 * @param {String} options the text to type
 		 * @param {Function} [callback] a function to callback
 		 */
-		_type: function (options, element, callback) {
+		_type: function (element, options, callback) {
 			//break it up into parts ...
 			//go through each type and run
 			var parts = (options + "")
@@ -884,7 +884,7 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 					if (part.length > 1) {
 						part = part.substr(1, part.length - 2);
 					}
-					self._key(part, el, runNextPart);
+					self._key(el, part, runNextPart);
 				};
 
 			runNextPart();

--- a/src/key.support.js
+++ b/src/key.support.js
@@ -42,22 +42,22 @@ steal('src/synthetic.js', 'src/key.js', function (Syn) {
 			};
 			// Firefox 4 won't write key events if the element isn't focused
 			Syn.__tryFocus(inputter);
-			Syn.trigger("keypress", "\r", inputter);
+			Syn.trigger(inputter, "keypress", "\r");
 
-			Syn.trigger("keypress", "a", inputter);
+			Syn.trigger(inputter, "keypress", "a");
 			Syn.support.keyCharacters = inputter.value === "a";
 
 			inputter.value = "a";
-			Syn.trigger("keypress", "\b", inputter);
+			Syn.trigger(inputter, "keypress", "\b");
 			Syn.support.backspaceWorks = inputter.value === "";
 
 			inputter.onchange = function () {
 				Syn.support.focusChanges = true;
 			};
 			Syn.__tryFocus(inputter);
-			Syn.trigger("keypress", "a", inputter);
+			Syn.trigger(inputter, "keypress", "a");
 			Syn.__tryFocus(form.childNodes[5]); // this will throw a change event
-			Syn.trigger("keypress", "b", inputter);
+			Syn.trigger(inputter, "keypress", "b");
 			Syn.support.keysOnNotFocused = inputter.value === "ab";
 
 			//test keypress \r on anchor submits
@@ -69,7 +69,7 @@ steal('src/synthetic.js', 'src/key.js', function (Syn) {
 				ev.returnValue = false;
 				return false;
 			});
-			Syn.trigger("keypress", "\r", anchor);
+			Syn.trigger(anchor, "keypress", "\r");
 
 			Syn.support.textareaCarriage = textarea.value.length === 4;
 

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -7,7 +7,7 @@ steal('./synthetic.js', function (Syn) {
 	Syn.mouse = {};
 	h.extend(Syn.defaults, {
 		mousedown: function (options) {
-			Syn.trigger("focus", {}, this);
+			Syn.trigger(this, "focus", {});
 		},
 		click: function () {
 			// prevents the access denied issue in IE if the click causes the element to be destroyed
@@ -52,7 +52,7 @@ steal('./synthetic.js', function (Syn) {
 
 				var form = Syn.closest(element, "form");
 				if (form) {
-					Syn.trigger("submit", {}, form);
+					Syn.trigger(form, "submit", {});
 				}
 
 			}
@@ -69,19 +69,19 @@ steal('./synthetic.js', function (Syn) {
 				//	element.checked = !element.checked;
 				//}
 				if (!Syn.support.clickChanges) {
-					Syn.trigger("change", {}, element);
+					Syn.trigger(element, "change", {});
 				}
 			}
 
 			//change a radio button
 			if (nodeName === "input" && type === "radio") { // need to uncheck others if not checked
 				if (radioChanged && !Syn.support.radioClickChanges) {
-					Syn.trigger("change", {}, element);
+					Syn.trigger(element, "change", {});
 				}
 			}
 			// change options
 			if (nodeName === "option" && createChange) {
-				Syn.trigger("change", {}, element.parentNode); //does not bubble
+				Syn.trigger(element.parentNode, "change", {}); //does not bubble
 				Syn.data(element, "createChange", false);
 			}
 		}

--- a/src/mouse.support.js
+++ b/src/mouse.support.js
@@ -22,19 +22,19 @@ steal('src/synthetic.js', 'src/mouse.js', function checkSupport(Syn) {
 	select = form.getElementsByTagName('select')[0];
 
 	//trigger click for linkHrefJS support, childNodes[6] === anchor
-	Syn.trigger('click', {}, form.childNodes[6]);
+	Syn.trigger(form.childNodes[6], 'click', {});
 
 	checkbox.checked = false;
 	checkbox.onchange = function () {
 		Syn.support.clickChanges = true;
 	};
 
-	Syn.trigger("click", {}, checkbox);
+	Syn.trigger(checkbox, "click", {});
 	Syn.support.clickChecks = checkbox.checked;
 
 	checkbox.checked = false;
 
-	Syn.trigger("change", {}, checkbox);
+	Syn.trigger(checkbox, "change", {});
 
 	Syn.support.changeChecks = checkbox.checked;
 
@@ -45,18 +45,18 @@ steal('src/synthetic.js', 'src/mouse.js', function checkSupport(Syn) {
 		Syn.support.clickSubmits = true;
 		return false;
 	};
-	Syn.trigger("click", {}, submit);
+	Syn.trigger(submit, "click", {});
 
 	form.childNodes[1].onchange = function () {
 		Syn.support.radioClickChanges = true;
 	};
-	Syn.trigger("click", {}, form.childNodes[1]);
+	Syn.trigger(form.childNodes[1], "click", {});
 
 	Syn.bind(div, 'click', function onclick() {
 		Syn.support.optionClickBubbles = true;
 		Syn.unbind(div, 'click', onclick);
 	});
-	Syn.trigger("click", {}, select.firstChild);
+	Syn.trigger(select.firstChild, "click", {});
 
 	Syn.support.changeBubbles = Syn.eventSupported('change');
 
@@ -64,8 +64,8 @@ steal('src/synthetic.js', 'src/mouse.js', function checkSupport(Syn) {
 	div.onclick = function () {
 		Syn.support.mouseDownUpClicks = true;
 	};
-	Syn.trigger("mousedown", {}, div);
-	Syn.trigger("mouseup", {}, div);
+	Syn.trigger(div, "mousedown", {});
+	Syn.trigger(div, "mouseup", {});
 
 	document.documentElement.removeChild(div);
 

--- a/test/qunit/key_test.js
+++ b/test/qunit/key_test.js
@@ -21,19 +21,19 @@ steal("src/synthetic.js", function (Syn) {
 	test("Key Characters", function () {
 		st.g("key")
 			.value = "";
-		Syn.key("a", "key");
+		Syn.key("key", "a");
 		equal(st.g("key")
 			.value, "a", "a written");
 
 		st.g("key")
 			.value = "";
-		Syn.key("A", "key");
+		Syn.key("key", "A");
 		equal(st.g("key")
 			.value, "A", "A written");
 
 		st.g("key")
 			.value = "";
-		Syn.key("1", "key");
+		Syn.key("key", "1");
 		equal(st.g("key")
 			.value, "1", "1 written");
 	});
@@ -58,7 +58,7 @@ steal("src/synthetic.js", function (Syn) {
 			return false;
 		});
 		stop();
-		Syn.key("\r", "key", function () {
+		Syn.key("key", "\r", function () {
 			equal(submit, 1, "submit on keypress");
 			equal(change, 1, "submit on keypress");
 			start();
@@ -76,7 +76,7 @@ steal("src/synthetic.js", function (Syn) {
 			return false;
 		});
 		stop();
-		Syn.key("\r", "focusLink", function () {
+		Syn.key("focusLink", "\r", function () {
 			equal(clicked, 1, "clicked");
 			start();
 		});
@@ -93,7 +93,7 @@ steal("src/synthetic.js", function (Syn) {
 		st.binder("key", "input", recorder);
 		st.binder("key", "keyup", recorder);
 		stop();
-		Syn.key("B", "key", function () {
+		Syn.key("key", "B", function () {
 			var expected = ["keydown", "keypress", "keyup"];
 			if (Syn.support.oninput) {
 				expected.splice(2, 0, "input");
@@ -108,7 +108,7 @@ steal("src/synthetic.js", function (Syn) {
 		st.g('synTextArea')
 			.value = "";
 		stop();
-		Syn.type("ab\rcd", "synTextArea", function () {
+		Syn.type("synTextArea", "ab\rcd", function () {
 			equal(st.g('synTextArea')
 				.value.replace("\r", ""), "ab\ncd", "typed new line correctly");
 			start();
@@ -119,10 +119,10 @@ steal("src/synthetic.js", function (Syn) {
 		st.g("key")
 			.value = "";
 		stop();
-		Syn.type("abc", "key", function () {
+		Syn.type("key", "abc", function () {
 			equal(st.g("key")
 				.value, "abc", "abc written");
-			Syn.key("\b", "key");
+			Syn.key("key", "\b");
 			equal(st.g("key")
 				.value, "ab", "ab written (key deleted)");
 			start();
@@ -149,7 +149,7 @@ steal("src/synthetic.js", function (Syn) {
 				.value;
 		});
 		stop();
-		Syn.key("J", "key", function () {
+		Syn.key("key", "J", function () {
 			equal(upVal, "J", "Up Typing works");
 			equal(pressVal, "", "Press Typing works");
 			equal(downVal, "", "Down Typing works");
@@ -195,7 +195,7 @@ steal("src/synthetic.js", function (Syn) {
 					start();
 					return;
 				}
-				Syn.key(name, "scrolldiv");
+				Syn.key("scrolldiv", name);
 			};
 		for (var name in keyTest) {
 			if (keyTest.hasOwnProperty(name)) {
@@ -247,7 +247,7 @@ steal("src/synthetic.js", function (Syn) {
 		keyEl.value = "012345";
 		selectText(keyEl, 1, 3);
 
-		Syn.key("delete", "key");
+		Syn.key("key", "delete");
 
 		equal(keyEl.value, "0345", "delete range works");
 
@@ -255,58 +255,58 @@ steal("src/synthetic.js", function (Syn) {
 		keyEl.value = "012345";
 		selectText(keyEl, 2);
 
-		Syn.key("delete", "key");
+		Syn.key("key", "delete");
 		equal(keyEl.value, "01345", "delete works");
 
 		// test character range
 		keyEl.value = "123456";
 		selectText(keyEl, 1, 3);
 
-		Syn.key("a", "key");
+		Syn.key("key", "a");
 		equal(keyEl.value, "1a456", "character range works");
 
 		// test character key
 		keyEl.value = "123456";
 		selectText(keyEl, 2);
 
-		Syn.key("a", "key");
+		Syn.key("key", "a");
 		equal(keyEl.value, "12a3456", "character insertion works");
 
 		// test backspace range
 		keyEl.value = "123456";
 		selectText(keyEl, 1, 3);
-		Syn.key("\b", "key");
+		Syn.key("key", "\b");
 		equal(keyEl.value, "1456", "backspace range works");
 
 		// test backspace key
 		keyEl.value = "123456";
 		selectText(keyEl, 2);
-		Syn.key("\b", "key");
+		Syn.key("key", "\b");
 		equal(keyEl.value, "13456", "backspace works");
 
 		// test textarea ranges
 		textAreaEl.value = "123456";
 		selectText(textAreaEl, 1, 3);
 
-		Syn.key("delete", textAreaEl);
+		Syn.key(textAreaEl, "delete");
 		equal(textAreaEl.value, "1456", "delete range works in a textarea");
 
 		// test textarea ranges
 		textAreaEl.value = "123456";
 		selectText(textAreaEl, 1, 3);
-		Syn.key("a", textAreaEl);
+		Syn.key(textAreaEl, "a");
 		equal(textAreaEl.value, "1a456", "character range works in a textarea");
 
 		// test textarea ranges
 		textAreaEl.value = "123456";
 		selectText(textAreaEl, 1, 3);
-		Syn.key("\b", textAreaEl);
+		Syn.key(textAreaEl, "\b");
 		equal(textAreaEl.value, "1456", "backspace range works in a textarea");
 
 		// test textarea ranges
 		textAreaEl.value = "123456";
 		selectText(textAreaEl, 1, 3);
-		Syn.key("\r", textAreaEl);
+		Syn.key(textAreaEl, "\r");
 
 		equal(textAreaEl.value.replace("\r", ""), "1\n456", "return range works in a textarea");
 
@@ -331,7 +331,7 @@ steal("src/synthetic.js", function (Syn) {
 		stop();
 		//give ie a second to focus
 		setTimeout(function () {
-			Syn.type('\r\tSecond\tThird\tFourth', 'first', function () {
+			Syn.type('first', '\r\tSecond\tThird\tFourth', function () {
 				equal(clicked, 1, "clickd first");
 				equal(st.g('second')
 					.value, "Second", "moved to second");
@@ -361,7 +361,7 @@ steal("src/synthetic.js", function (Syn) {
 		stop();
 		//give ie a second to focus
 		setTimeout(function () {
-			Syn.type('[shift]4\t3\t2\t\r[shift-up]', 'fourth', function () {
+			Syn.type('fourth', '[shift]4\t3\t2\t\r[shift-up]', function () {
 				equal(clicked, 1, "clickd first");
 				equal(st.g('second')
 					.value, "2", "moved to second");
@@ -376,11 +376,11 @@ steal("src/synthetic.js", function (Syn) {
 
 	test("Type left and right", function () {
 		stop();
-		Syn.type("012345678[left][left][left]\b", 'key', function () {
+		Syn.type('key', "012345678[left][left][left]\b", function () {
 			equal(st.g('key')
 				.value, "01234678", "left works");
 
-			Syn.type("[right][right]a", 'key', function () {
+			Syn.type('key', "[right][right]a", function () {
 				equal(st.g('key')
 					.value, "0123467a8", "right works");
 				start();
@@ -391,7 +391,7 @@ steal("src/synthetic.js", function (Syn) {
 	});
 	test("Type left and delete", function () {
 		stop();
-		Syn.type("123[left][delete]", 'key', function () {
+		Syn.type('key', "123[left][delete]", function () {
 			equal(st.g('key')
 				.value, "12", "left delete works");
 			start();
@@ -405,7 +405,7 @@ steal("src/synthetic.js", function (Syn) {
 		st.binder('key', 'keypress', function (ev) {
 			shift = ev.shiftKey;
 		});
-		Syn.type("[shift]A[shift-up]", 'key', function () {
+		Syn.type('key', "[shift]A[shift-up]", function () {
 			ok(shift, "Shift key on");
 			start();
 		});
@@ -417,9 +417,9 @@ steal("src/synthetic.js", function (Syn) {
 		st.binder('inner', 'click', function (ev) {
 			shift = ev.shiftKey;
 		});
-		Syn.type("[shift]A", 'key')
-			.click({}, 'inner')
-			.type("[shift-up]", 'key', function () {
+		Syn.type('key', "[shift]A")
+			.click('inner', {})
+			.type('key', "[shift-up]", function () {
 				ok(shift, "Shift key on click");
 				start();
 			});
@@ -428,11 +428,11 @@ steal("src/synthetic.js", function (Syn) {
 	test("Typing Shift Left and Right", function () {
 		stop();
 
-		Syn.type("012345678[shift][left][left][left][shift-up]\b[left]\b", 'key', function () {
+		Syn.type('key', "012345678[shift][left][left][left][shift-up]\b[left]\b", function () {
 			equal(st.g('key')
 				.value, "01235", "shift left works");
 
-			Syn.type("[left][left][shift][right][right]\b[shift-up]", 'key', function () {
+			Syn.type('key', "[left][left][shift][right][right]\b[shift-up]", function () {
 
 				equal(st.g('key')
 					.value, "015", "shift right works");
@@ -444,7 +444,7 @@ steal("src/synthetic.js", function (Syn) {
 
 	test("shift characters", function () {
 		stop();
-		Syn.type("@", 'key', function () {
+		Syn.type('key', "@", function () {
 			equal(st.g('key')
 				.value, "@", "@ character works");
 			start();
@@ -460,7 +460,7 @@ steal("src/synthetic.js", function (Syn) {
 			start();
 		});
 
-		Syn.type("[down]", 'key', function () {});
+		Syn.type('key', "[down]", function () {});
 	});
 
 	test("Key codes of like-keys", function () {
@@ -491,7 +491,7 @@ steal("src/synthetic.js", function (Syn) {
 				ok(ev.which === ev.keyCode);
 				done();
 			});
-			Syn.type("[" + key + "]", "key");
+			Syn.type("key", "[" + key + "]");
 		};
 
 		for (var key in keys) {
@@ -510,12 +510,12 @@ steal("src/synthetic.js", function (Syn) {
 			ok(true, "keypress called");
 			start();
 		});
-		Syn.type("a", 'key', function () {});
+		Syn.type('key', "a", function () {});
 	});
 
 	test("typing in a number works", function () {
 		stop();
-		Syn.type(9999, 'key', function () {
+		Syn.type('key', 9999, function () {
 			equal(st.g('key')
 				.value, "9999", "typing in numbers works");
 			start();
@@ -524,7 +524,7 @@ steal("src/synthetic.js", function (Syn) {
 
 	test("typing in a contenteditable works", function () {
 		stop();
-		Syn.type("hello world", "editable", function () {
+		Syn.type("editable", "hello world", function () {
 			var editable = st.g("editable");
 			var text = editable.textContent || editable.innerText;
 			equal(text, "hello world", "Content editable was edited");

--- a/test/qunit/mouse_test.js
+++ b/test/qunit/mouse_test.js
@@ -38,7 +38,7 @@ steal("src/synthetic.js", function (Syn) {
 
 		st.unbinder("outer", "mouseover", mouseoverf);
 		equal(mouseover, 1, "Mouseover");
-		Syn("mouseover", {}, 'inner');
+		Syn("mouseover", 'inner', {});
 
 		equal(mouseover, 1, "Mouseover on no event handlers");
 		st.g("qunit-test-area")
@@ -57,8 +57,8 @@ steal("src/synthetic.js", function (Syn) {
 				return false;
 			};
 		st.bind(st.g("outer"), "submit", submitf);
-		Syn.trigger("click", {}, st.g("submit"));
-		Syn("submit", {}, "outer");
+		Syn.trigger(st.g("submit"), "click", {});
+		Syn("submit", "outer", {});
 
 		equal(submit, 2, "Click on submit");
 
@@ -73,7 +73,7 @@ steal("src/synthetic.js", function (Syn) {
 			};
 		st.binder("inner", "click", clickf);
 
-		Syn.trigger("click", {}, st.g("submit"));
+		Syn.trigger(st.g("submit"), "click", {});
 
 		equal(submit, 2, "Submit prevented");
 		equal(click, 1, "Clicked");
@@ -91,12 +91,12 @@ steal("src/synthetic.js", function (Syn) {
 		st.g("checkbox")
 			.checked = false;
 
-		Syn.trigger("click", {}, st.g("checkbox"));
+		Syn.trigger(st.g("checkbox"), "click", {});
 
 		ok(st.g("checkbox")
 			.checked, "click checks on");
 
-		Syn.trigger("click", {}, st.g("checkbox"));
+		Syn.trigger(st.g("checkbox"), "click", {});
 
 		ok(!st.g("checkbox")
 			.checked, "click checks off");
@@ -111,7 +111,7 @@ steal("src/synthetic.js", function (Syn) {
 				.checked, "check is on during click");
 		});
 
-		Syn.trigger("click", {}, st.g("checkbox"));
+		Syn.trigger(st.g("checkbox"), "click", {});
 	});
 
 	test("Select is changed on click", function () {
@@ -129,15 +129,15 @@ steal("src/synthetic.js", function (Syn) {
 			select2++;
 		});
 
-		Syn.trigger('click', {}, st.g('s1o2'));
+		Syn.trigger(st.g('s1o2'), 'click', {});
 		equal(st.g('s1')
 			.selectedIndex, 1, "select worked");
 		equal(select1, 1, "change event");
-		Syn.trigger('click', {}, st.g('s2o2'));
+		Syn.trigger(st.g('s2o2'), 'click', {});
 		equal(st.g('s2')
 			.selectedIndex, 1, "select worked");
 		equal(select2, 1, "change event");
-		Syn.trigger('click', {}, st.g('s1o1'));
+		Syn.trigger(st.g('s1o1'), 'click', {});
 		equal(st.g('s1')
 			.selectedIndex, 0, "select worked");
 		equal(select1, 2, "change event");
@@ -191,13 +191,13 @@ steal("src/synthetic.js", function (Syn) {
 			radio2++;
 		});
 
-		Syn.trigger("click", {}, st.g("radio1"));
+		Syn.trigger(st.g("radio1"), "click", {});
 
 		equal(radio1, 1, "radio event");
 		ok(st.g("radio1")
 			.checked, "radio checked");
 
-		Syn.trigger("click", {}, st.g("radio2"));
+		Syn.trigger(st.g("radio2"), "click", {});
 
 		equal(radio2, 1, "radio event");
 		ok(st.g("radio2")
@@ -235,7 +235,7 @@ steal("src/synthetic.js", function (Syn) {
 		});
 
 		stop();
-		Syn.click({}, "focusme", function () {
+		Syn.click("focusme", {}, function () {
 			start();
 		});
 
@@ -243,7 +243,7 @@ steal("src/synthetic.js", function (Syn) {
 
 	test("Click Anchor Runs HREF JavaScript", function () {
 		stop();
-		Syn.trigger("click", {}, st.g("jsHref"));
+		Syn.trigger(st.g("jsHref"), "click", {});
 		// Firefox triggers href javascript async so need to
 		// wait for it to complete.
 		setTimeout(function () {
@@ -259,7 +259,7 @@ steal("src/synthetic.js", function (Syn) {
 			ok(target.href.indexOf("#aHash") > -1, "got href");
 		});
 
-		Syn.click({}, "jsHrefHash", function () {
+		Syn.click("jsHrefHash", {}, function () {
 			equal(window.location.hash, "#aHash", "hash set ...");
 			start();
 			window.location.hash = "";
@@ -289,7 +289,7 @@ steal("src/synthetic.js", function (Syn) {
 		stop();
 		//need to give browsers a second to show element
 
-		Syn.click({}, "focusme", function () {
+		Syn.click("focusme", {}, function () {
 			start();
 		});
 
@@ -311,9 +311,9 @@ steal("src/synthetic.js", function (Syn) {
 			});
 
 			stop();
-			Syn.click({}, "one")
+			Syn.click("one", {})
 				.key("a")
-				.click({}, "two", function () {
+				.click("two", {}, function () {
 					start();
 					equal(change, 1, "Change called once");
 					equal(blur, 1, "Blur called once");
@@ -331,9 +331,9 @@ steal("src/synthetic.js", function (Syn) {
 			});
 
 			stop();
-			Syn.click({}, "one")
+			Syn.click("one", {})
 				.key("a")
-				.click({}, document.documentElement, function () {
+				.click(document.documentElement, {}, function () {
 					start();
 					equal(change, 1, "Change called once");
 				});
@@ -348,7 +348,7 @@ steal("src/synthetic.js", function (Syn) {
 			context++;
 		});
 
-		Syn.rightClick({}, "one", function () {
+		Syn.rightClick("one", {}, function () {
 			if (Syn.mouse.browser.contextmenu) {
 				equal(1, context, "context was called");
 			} else {
@@ -370,7 +370,7 @@ steal("src/synthetic.js", function (Syn) {
 			eventSequence.push('click');
 		});
 
-		Syn.dblclick({}, "dblclickme", function () {
+		Syn.dblclick("dblclickme", {}, function () {
 			equal(eventSequence.join(', '), 'click, click, dblclick', 'expected event sequence for doubleclick');
 			start();
 		});
@@ -392,7 +392,7 @@ steal("src/synthetic.js", function (Syn) {
 			ok(true, "h3 was clicked");
 			
 		});
-		Syn.click( el ,{}, function(){
+		Syn.click(el ,{}, function(){
 			start();
 		})
 

--- a/test/qunit/syn.schedule.html
+++ b/test/qunit/syn.schedule.html
@@ -13,7 +13,7 @@
 
 		steal('src/syn.js').then(function(){
 			var body = document.body;
-			Syn.click({}, body).delay(function(){}, 0);
+			Syn.click(body, {}).delay(function(){}, 0);
 		});
 	</script>
 </body>


### PR DESCRIPTION
For example `Syn.type(options, element, callback)` becomes `Syn.type(element, options, callback)`

Needed for:
- [x] Syn.trigger
- [x] Syn.key
- [x] Syn.type
- [x] Syn.click
- [x] Syn.dblclick
- [x] Syn.rightClick
- [x] Syn.drag
- [x] Syn.move
- [x] Syn.then
