### PR TITLE
Make enter key on a form input trigger click on first submit button

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -535,6 +535,18 @@ steal('./synthetic.js', './typeable.js', './browsers.js', function (Syn) {
 					var form = Syn.closest(this, "form");
 					if (form) {
 						Syn.trigger("submit", {}, form);
+
+						//click first submit button
+						var implicitSubmitButton = Syn.jquery()(form)
+							.find("button, input[type=submit]")
+							.filter(function (i, button) {
+								//buttons are implicitly submit buttons
+								// unless they have type="button"
+								return button.type != "button"
+							})[0];
+						if (implicitSubmitButton) {
+							Syn.trigger("click", {}, implicitSubmitButton);
+						}
 					}
 
 				}


### PR DESCRIPTION
When you press enter on an input inside of a form, the browser fires a submit event on the form, and also fires a click event on the first submit button of the form, if there is one. <button> elements default to type "submit" if a type is not specified.

This behavior is illustrated in this jsfiddle: http://jsfiddle.net/dkordik/y25r4qnp/

Closes #65
