### PR TITLE
mouse buttons are correct in IE > 8

### DIFF
--- a/src/browsers.js
+++ b/src/browsers.js
@@ -324,10 +324,10 @@ steal('./synthetic.js', './mouse.js', function (Syn) {
 			},
 			"left": {
 				"mousedown": {
-					"button": 1
+					"button": window.addEventListener ? 0 : 1
 				},
 				"mouseup": {
-					"button": 1
+					"button": window.addEventListener ? 0 : 1
 				},
 				"click": {
 					"button": 0


### PR DESCRIPTION
As I commented in issue #52, this sets the correct LMB number in the mousedown, mouseup events on IE >= 9.

(Source, for IE >= 9: http://msdn.microsoft.com/en-us/library/ie/ff974877%28v=vs.85%29.aspx)
(Source, for IE < 9: http://www.quirksmode.org/js/events_properties.html#button)
