### PR TITLE
mouse.support.js: Fix scheduled execution in case of no document.body.

### DIFF
--- a/src/mouse.support.js
+++ b/src/mouse.support.js
@@ -2,11 +2,10 @@ var syn = require('./synthetic');
 require('./mouse');
 
 
-if (!document.body) {
-	syn.schedule(function () {
-		checkSupport(syn);
-	}, 1);
-} else {
+(function checkSupport() {
+	if (!document.body) {
+		return syn.schedule(checkSupport, 1);
+	}
 	window.__synthTest = function () {
 		syn.support.linkHrefJS = true;
 	};
@@ -71,7 +70,7 @@ if (!document.body) {
 	
 	//check stuff
 	syn.support.ready++;
-}
+}());
 
 
 


### PR DESCRIPTION
Commit 5cf4553 changed the structure of this file, it does still call `checkSupport`, but the function no longer exists.