### PR TITLE
Syn.type - do not throw when selection is not supported.

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -6,12 +6,25 @@ require('./browsers');
 var h = syn.helpers,
 
 	formElExp = /input|textarea/i,
+	// selection is not supported by some inputs and would throw in Chrome.
+	supportsSelection = function(el) {
+		var result;
+
+		try {
+			result = el.selectionStart !== undefined;
+		}
+		catch(e) {
+			result = false;
+		}
+
+		return result;
+	},
 	// gets the selection of an input or textarea
 	getSelection = function (el) {
 		var real, r, start;
 
 		// use selectionStart if we can
-		if (el.selectionStart !== undefined) {
+		if (supportsSelection(el)) {
 			// this is for opera, so we don't have to focus to type how we think we would
 			if (document.activeElement && document.activeElement !== el &&
 				el.selectionStart === el.selectionEnd && el.selectionStart === 0) {
@@ -291,7 +304,7 @@ h.extend(syn, {
 
 	// selects text on an element
 	selectText: function (el, start, end) {
-		if (el.setSelectionRange) {
+		if (supportsSelection(el)) {
 			if (!end) {
 				syn.__tryFocus(el);
 				el.setSelectionRange(start, start);
@@ -552,14 +565,14 @@ h.extend(syn.key, {
 				syn.trigger(this, "click", {});
 			}
 		},
-		// 
+		//
 		// Gets all focusable elements.  If the element (this)
 		// doesn't have a tabindex, finds the next element after.
-		// If the element (this) has a tabindex finds the element 
+		// If the element (this) has a tabindex finds the element
 		// with the next higher tabindex OR the element with the same
 		// tabindex after it in the document.
 		// @return the next element
-		// 
+		//
 		'\t': function (options, scope) {
 			// focusable elements
 			var focusEls = getFocusable(this),
@@ -745,7 +758,7 @@ var convert = {
 };
 
 /**
- * 
+ *
  */
 h.extend(syn.init.prototype, {
 	/**

--- a/test/key_test.js
+++ b/test/key_test.js
@@ -167,7 +167,7 @@ QUnit.test("page down, page up, home, end", function () {
 		"<div id='scrolldiv' style='width:100px;height:200px;overflow-y:scroll;' tabindex='0'>" +
 		"<div id='innerdiv' style='height:1000px;'><a href='javascript://'>Scroll on me</a></div></div>";
 
-	//reset the scroll top	
+	//reset the scroll top
 	st.g("scrolldiv")
 		.scrollTop = 0;
 
@@ -531,6 +531,23 @@ QUnit.test("typing in a contenteditable works", function () {
 		var editable = st.g("editable");
 		var text = editable.textContent || editable.innerText;
 		equal(text, "hello world", "Content editable was edited");
+		start();
+	});
+});
+
+QUnit.test("typing in an input type=number works", function() {
+	stop();
+
+	st.g("qunit-fixture").innerHTML =
+		"<form id='outer'>" +
+			"<div id='inner'>" +
+				"<input type='number' pattern='[0-9]*' id='number' value='' />" +
+			"</div>" +
+		"</form>";
+
+	syn.type("number", 123, function() {
+		var val = st.g("number").value;
+		equal(val, "123", "number input was edited");
 		start();
 	});
 });


### PR DESCRIPTION
Closes #115.

Some background on the issue:
http://stackoverflow.com/questions/22381837/how-to-overcome-whatwg-w3c-chrome-version-33-0-1750-146-regression-bug-with-i
https://www.w3.org/Bugs/Public/show_bug.cgi?id=24796

![screen shot 2016-03-23 at 13 16 27](https://cloud.githubusercontent.com/assets/724877/13992318/5c9a31a0-f0fa-11e5-9a03-344a0cc55a27.png)
