### PR TITLE
syn#122 - Syn compatibility fix for FireFox 51.0.1, error while using…

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -11,7 +11,7 @@ var h = syn.helpers,
 		var result;
 
 		try {
-			result = el.selectionStart !== undefined;
+			result = ((el.selectionStart !== undefined) && (el.selectionStart !== null));
 		}
 		catch(e) {
 			result = false;


### PR DESCRIPTION
… setSelectedRange, came from most browsers returning undef but firefox returns null. Simple fix: report unsupported if undef OR null