### PR TITLE
Fix the versioning & publishing scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "main": "dist/cjs/syn.js",
   "scripts": {
     "preversion": "npm test && npm run build",
-    "version": "git commit -am \"Update dist for release\" && git checkout -b release && git add -f dist/",
-    "postversion": "git push --tags && git checkout master && git branch -D release && git push",
+    "postversion": "git push --tags && git push",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",


### PR DESCRIPTION
Make sure `dist` is included when publishing to npm.

Fixes #125