### PR TITLE
Fixes to the ctrl and alt keys, added support for meta key. Still wor…

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -11,7 +11,7 @@ var h = syn.helpers,
 		var result;
 
 		try {
-			result = ((el.selectionStart !== undefined) && (el.selectionStart !== null));
+			result = el.selectionStart !== undefined && el.selectionStart !== null;
 		}
 		catch(e) {
 			result = false;
@@ -163,7 +163,7 @@ h.extend(syn, {
 	 * up        - moves the cursor up
 	 * down      - moves the cursor down
 	 * f1-12     - function buttons
-	 * shift, ctrl, alt - special keys
+	 * shift, ctrl, alt, meta - special keys
 	 * pause-break      - the pause button
 	 * scroll-lock      - locks scrolling
 	 * caps      - makes caps
@@ -192,6 +192,7 @@ h.extend(syn, {
 		'shift': 16,
 		'ctrl': 17,
 		'alt': 18,
+		'meta': 91,
 
 		//weird
 		'pause-break': 19,
@@ -411,7 +412,7 @@ h.extend(syn.key, {
 	},
 	//types of event keys
 	kinds: {
-		special: ["shift", 'ctrl', 'alt', 'caps'],
+		special: ["shift", 'ctrl', 'alt', 'meta', 'caps'],
 		specialChars: ["\b"],
 		navigation: ["page-up", 'page-down', 'end', 'home', 'left', 'up', 'right', 'down', 'insert', 'delete'],
 		'function': ['f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12']
@@ -670,6 +671,12 @@ h.extend(syn.key, {
 			return null;
 		},
 		'ctrl': function () {
+			return null;
+		},
+		'alt': function () {
+			return null;
+		},
+		'meta': function () {
 			return null;
 		}
 	}

--- a/src/key.js
+++ b/src/key.js
@@ -188,7 +188,7 @@ h.extend(syn, {
 		//enter
 		'\r': 13,
 
-		//special
+		//modifier keys
 		'shift': 16,
 		'ctrl': 17,
 		'alt': 18,

--- a/test/key_test.js
+++ b/test/key_test.js
@@ -454,6 +454,84 @@ QUnit.test("shift characters", function () {
 	});
 });
 
+QUnit.test("ctrl keycodes", function () {
+	stop();
+
+	var keyIsDown = false;
+	st.binder("key", "keydown", function (ev) {
+		keyIsDown = ev.ctrlKey;
+		ok(ev.ctrlKey, "Ctrl key functioning. Expected: " + ev.which + ", Actual: "+ev.keyCode);
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	var keyIsUp = true;
+	st.binder("key", "keyup", function (ev) {
+		keyIsUp = ev.ctrlKey;
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	syn.type('key', "[ctrl]", function () {
+		ok(keyIsDown, "ctrl modifier key pressed successfully");
+
+		syn.type('key', "[ctrl-up]", function () {
+			ok(!keyIsUp, "ctrl modifier key released successfully");
+			start();
+		});
+	});
+});
+
+QUnit.test("alt keycodes", function () {
+	stop();
+
+	var keyIsDown = false;
+	st.binder("key", "keydown", function (ev) {
+		keyIsDown = ev.altKey;
+		ok(ev.altKey, "Alt key functioning. Expected: " + ev.which + ", Actual: "+ev.keyCode);
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	var keyIsUp = true;
+	st.binder("key", "keyup", function (ev) {
+		keyIsUp = ev.altKey;
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	syn.type('key', "[alt]", function () {
+		ok(keyIsDown, "alt modifier key pressed successfully");
+
+		syn.type('key', "[alt-up]", function () {
+			ok(!keyIsUp, "alt modifier key released successfully");
+			start();
+		});
+	});
+});
+
+QUnit.test("meta keycodes", function () {
+	stop();
+
+	var keyIsDown = false;
+	st.binder("key", "keydown", function (ev) {
+		keyIsDown = ev.metaKey;
+		ok(ev.metaKey, "Meta key functioning. Expected: " + ev.which + ", Actual: "+ev.keyCode);
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	var keyIsUp = true;
+	st.binder("key", "keyup", function (ev) {
+		keyIsUp = ev.metaKey;
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	syn.type('key', "[meta]", function () {
+		ok(keyIsDown, "meta modifier key pressed successfully");
+
+		syn.type('key', "[meta-up]", function () {
+			ok(!keyIsUp, "meta modifier key released successfully");
+			start();
+		});
+	});
+});
+
 test("number key codes", 2, function () {
 	stop();
 

--- a/test/key_test.js
+++ b/test/key_test.js
@@ -392,6 +392,7 @@ QUnit.test("Type left and right", function () {
 	});
 
 });
+
 QUnit.test("Type left and delete", function () {
 	stop();
 	syn.type('key', "123[left][delete]", function () {
@@ -401,6 +402,7 @@ QUnit.test("Type left and delete", function () {
 	});
 
 });
+
 QUnit.test("Typing Shift", function () {
 	stop();
 
@@ -413,6 +415,7 @@ QUnit.test("Typing Shift", function () {
 		start();
 	});
 });
+
 QUnit.test("Typing Shift then clicking", function () {
 	stop();
 
@@ -438,7 +441,7 @@ QUnit.test("Typing Shift Left and Right", function () {
 		syn.type('key', "[left][left][shift][right][right]\b[shift-up]", function () {
 
 			equal(st.g('key')
-				.value, "015", "shift right works");
+			.value, "015", "shift right works");
 			start();
 		});
 
@@ -450,6 +453,44 @@ QUnit.test("shift characters", function () {
 	syn.type('key', "@", function () {
 		equal(st.g('key')
 			.value, "@", "@ character works");
+		start();
+	});
+});
+
+
+QUnit.test("shift keycodes", function () {
+	stop();
+
+	var keyIsDown = false;
+	st.binder("key", "keydown", function (ev) {
+		keyIsDown = ev.shiftKey;
+		ok(ev.shiftKey, "Shift key functioning. Expected: " + ev.which + ", Actual: "+ev.keyCode);
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	var keyIsUp = true;
+	st.binder("key", "keyup", function (ev) {
+		keyIsUp = ev.shiftKey;
+		ok(ev.which === ev.keyCode, "which is normalized");
+	});
+	
+	syn.type('key', "[shift]", function () {
+		ok(keyIsDown, "shift modifier key pressed successfully");
+
+		syn.type('key', "[shift-up]", function () {
+			ok(!keyIsUp, "shift modifier key released successfully");
+			start();
+		});
+	});
+});
+
+QUnit.test("shift practical test", function () {
+	stop();
+	
+	syn.type('key', "hello [shift]world[shift-up]", function () {
+		// TODO: Fix this!
+		//equal(key.value, "hello WORLD", "uppercasing successful while using shift");
+		equal(true, true, "Test was not run due to known Syn issue : https://github.com/bitovi/syn/issues/97");
 		start();
 	});
 });
@@ -475,6 +516,23 @@ QUnit.test("ctrl keycodes", function () {
 
 		syn.type('key', "[ctrl-up]", function () {
 			ok(!keyIsUp, "ctrl modifier key released successfully");
+			start();
+		});
+	});
+});
+
+QUnit.test("ctrl practical test", function () {
+	stop();
+	
+	syn.type('key', "Hello World", function () {
+		ok(key.value, "Hello World");
+		equal(key.selectionStart, 11, "pre-selectAll has correct start of 11");
+		equal(key.selectionEnd, 11, "pre-selectAll has correct end of 11");
+
+		syn.type('key', "[ctrl]a[ctrl-up]", function () {
+			
+			equal(key.selectionStart, 0, "post-selectAll has correct start of 0");
+			equal(key.selectionEnd, 11, "post-selectAll has correct end of 11");
 			start();
 		});
 	});
@@ -531,6 +589,70 @@ QUnit.test("meta keycodes", function () {
 		});
 	});
 });
+
+// INSERT TEST disabled because of https://github.com/bitovi/syn/issues/131
+
+//QUnit.test("insert keycodes", function () {
+	//stop();
+
+	//st.binder("key", "keydown", function (ev) {
+	//	ok(ev.keyCode === 45, "Received expected insert keycode");
+	//	ok(ev.which === ev.keyCode, "which is normalized");
+	//	start();
+	//});
+
+	//syn.type('key', "[insert]", function () {});
+//});
+
+// INSERT TEST disabled because of https://github.com/bitovi/syn/issues/131
+
+//QUnit.test("insert practical test", function () {
+//	stop();
+	
+//	syn.type('key', "Hello World", function () {
+//		equal(key.value, "Hello World", "Verified initial state");
+//		selectText(key, 6, 6);
+
+		// TODO: this actually hangs the test. Should I be using something like insert-up ?
+		//syn.type('key', "[insert]Universe[insert-up]", function () {
+			//equal(key.value, "Hello Universe", "Verified modified state");
+			
+//			start();
+		//});
+//	});
+//});
+
+QUnit.test("caps keycodes", function () {
+	stop();
+
+	st.binder("key", "keydown", function (ev) {
+		ok(ev.keyCode === 20, "Received expected caps keycode");
+		ok(ev.which === ev.keyCode, "which is normalized");
+		start();
+	});
+
+	syn.type('key', "[caps]", function () {});
+});
+
+
+// CAPS TEST disabled because of https://github.com/bitovi/syn/issues/132
+
+//QUnit.test("caps practical test", function () {
+//	stop();
+	
+//	syn.type('key', "Hello", function () {
+//		equal(key.value, "Hello", "Verified initial state");
+
+		// TODO: this actually hangs the test. Should I be using something like insert-up ?
+		//syn.type('key', "[caps] universe[caps]", function () {
+		//	equal(key.value, "Hello UNIVERSE", "Verified modified state");
+			
+		//	start();
+		//});
+	//});
+//});
+
+
 
 test("number key codes", 2, function () {
 	stop();

--- a/test/mouse_test.js
+++ b/test/mouse_test.js
@@ -141,7 +141,15 @@ QUnit.test("Select is changed on click", function () {
 		select2 = 0;
 
 	st.g("qunit-fixture")
-		.innerHTML = '<select id="s1"><option id="s1o1">One</option><option id="s1o2">Two</option></select><select id="s2"><option id="s2o1">One</option><option id="s2o2">Two</option></select>';
+		.innerHTML = 
+			'<select id="s1">'+
+				'<option id="s1o1">One</option>'+
+				'<option id="s1o2">Two</option>'+
+			'</select>'+
+			'<select id="s2">'+
+				'<option id="s2o1">One</option>'+
+				'<option id="s2o2">Two</option>'+
+			'</select>';
 
 	st.bind(st.g("s1"), "change", function (ev) {
 		select1++;
@@ -265,19 +273,19 @@ QUnit.test("Click! Event Order", syn.skipFocusTests ? 3 : 4, function () {
 
 QUnit.test("Click! Pointer Event Order", syn.support.pointerEvents ? 3 : 0, function () {
 	var order = 0;
-	st.g("qunit-fixture").innerHTML = "<input id='focusme'/>";
+	st.g("qunit-fixture").innerHTML = "<input id='pointerTarget'/>";
 
 	if(syn.support.pointerEvents){ // skips test on browsers that do not support pointer events
 
-		st.binder("focusme", "pointerdown", function () {
+		st.binder("pointerTarget", "pointerdown", function () {
 			QUnit.equal(++order, 1, "pointerdown");
 		});
 
-		st.binder("focusme", "pointerup", function () {
+		st.binder("pointerTarget", "pointerup", function () {
 			QUnit.equal(++order, 2, "pointerup");
 		});
 
-		st.binder("focusme", "click", function (ev) {
+		st.binder("pointerTarget", "click", function (ev) {
 			QUnit.equal(++order, 3, "click");
 			if (ev.preventDefault) {
 				ev.preventDefault();
@@ -287,26 +295,26 @@ QUnit.test("Click! Pointer Event Order", syn.support.pointerEvents ? 3 : 0, func
 	}
 		
 	stop();
-	syn.click("focusme", {}, function () {
+	syn.click("pointerTarget", {}, function () {
 		QUnit.start();
 	});
 });
 
 QUnit.test("Click! Touch Event Order", syn.support.touchEvents ? 3 : 0, function () {
 	var order = 0;
-	st.g("qunit-fixture").innerHTML = "<input id='focusme'/>";
+	st.g("qunit-fixture").innerHTML = "<input id='touchTarget'/>";
 
 	if(syn.support.touchEvents){ // skips test on browsers that do not support touch events
 
-		st.binder("focusme", "touchstart", function () {
+		st.binder("touchTarget", "touchstart", function () {
 			QUnit.equal(++order, 1, "touchstart");
 		});
 
-		st.binder("focusme", "touchend", function () {
+		st.binder("touchTarget", "touchend", function () {
 			QUnit.equal(++order, 2, "touchend");
 		});
 
-		st.binder("focusme", "click", function (ev) {
+		st.binder("touchTarget", "click", function (ev) {
 			QUnit.equal(++order, 3, "click");
 			if (ev.preventDefault) {
 				ev.preventDefault();
@@ -316,7 +324,7 @@ QUnit.test("Click! Touch Event Order", syn.support.touchEvents ? 3 : 0, function
 	}
 		
 	stop();
-	syn.click("focusme", {}, function () {
+	syn.click("touchTarget", {}, function () {
 		QUnit.start();
 	});
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -3,4 +3,3 @@ require('test/key_test');
 require('test/drag_test');
 require('test/mouse_test');
 require('test/typeable_test');
-


### PR DESCRIPTION
…king on insert, haven't yet tested capslock. Tests for ctrl, alt, meta include keydowns and keyups to ensure that they are released. However, no tests exist yet for actions like ctrl+a and seeing if it selects-all (etc), as some of these are browser-specific behaviors. I will add something to that effect next. Also I want to add some multiple modifier (shift+ctrl, etc) tests.

Also some minor formatting changes. Renamed variables that were vague or incorrect from a previous submission. Stuff like that.