### PR TITLE
Adding PointerEvents to RightClick

### DIFF
--- a/src/mouse.js
+++ b/src/mouse.js
@@ -88,7 +88,7 @@ h.extend(syn.defaults, {
 	}
 });
 
-//add create and setup behavior for mosue events
+//add create and setup behavior for mouse events
 h.extend(syn.create, {
 	mouse: {
 		options: function (type, options, element) {

--- a/src/synthetic.js
+++ b/src/synthetic.js
@@ -855,11 +855,17 @@ extend(syn.init.prototype, {
 	"_rightClick": function (element, options, callback) {
 		syn.helpers.addOffset(options, element);
 		var mouseopts = extend(extend({}, syn.mouse.browser.right.mouseup), options);
-
+		if(syn.support.pointerEvents){
+			syn.trigger(element, 'pointerdown', mouseopts);
+		}
+			
 		syn.trigger(element, "mousedown", mouseopts);
 
 		//timeout is b/c IE is stupid and won't call focus handlers
 		schedule(function () {
+			if(syn.support.pointerEvents){
+				syn.trigger(element, 'pointerup', mouseopts);
+			}
 			syn.trigger(element, "mouseup", mouseopts);
 			if (syn.mouse.browser.right.contextmenu) {
 				syn.trigger(element, "contextmenu", extend(extend({}, syn.mouse.browser.right.contextmenu), options));

--- a/test/mouse_test.js
+++ b/test/mouse_test.js
@@ -428,8 +428,7 @@ if (!syn.skipFocusTests) {
 	});
 }
 QUnit.test("Right Click", function () {
-	st.g("qunit-fixture")
-		.innerHTML = "<div id='one'>right click me</div>";
+	st.g("qunit-fixture").innerHTML = "<div id='one'>right click me</div>";
 	stop();
 	var context = 0;
 	st.binder("one", "contextmenu", function () {
@@ -445,6 +444,29 @@ QUnit.test("Right Click", function () {
 		QUnit.start();
 	});
 });
+
+
+QUnit.test("Right Click Issues PointerEvents", syn.support.pointerEvents ? 2 : 0, function () {
+	var order = 1;
+	st.g("qunit-fixture").innerHTML = "<input id='pointerTarget'/>";
+
+	if(syn.support.pointerEvents){ // skips test on browsers that do not support pointer events
+		st.binder("pointerTarget", "pointerdown", function (ev) {
+			QUnit.equal(ev.button, 2, "pointerdown");
+		});
+	}
+	
+	if(syn.support.pointerEvents){ // skips test on browsers that do not support pointer events
+		st.binder("pointerTarget", "pointerup", function (ev) {
+			QUnit.equal(ev.button, 2, "pointerup");
+		});
+	}		
+	stop();
+	syn.rightClick("pointerTarget", {}, function () {
+		QUnit.start();
+	});
+});
+
 
 QUnit.test("Double Click", function () {
 	st.g("qunit-fixture")


### PR DESCRIPTION
Adding PointerEvents to RightClick.

This still will not solve the TouchEvents or Touch-Pointer Events problems, but it will unblock all mouse users who want to automate rightclick (context click).