### PR TITLE
A touch job to fix the version number mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "main": "dist/cjs/syn.js",
   "scripts": {
     "preversion": "npm test && npm run build",


### PR DESCRIPTION
There's a version number mismatch between the site and the product, which is causing some linking to fail. The doc is 0.1 versions ahead.

At Chasen's request, do this touch-job, and then do a bugfix release, and everything should be sync'd.