### PR TITLE
Fixes to drag event accuracy

### DIFF
--- a/src/drag.js
+++ b/src/drag.js
@@ -113,8 +113,7 @@ var DragonDrop = {
 	},
 	
 	_drop: function(node){
-		var options = { bubbles:false, cancelable:true, buttons:2 };
-		debugger;
+		var options = { bubbles:true, cancelable:true, buttons:1 };
 		this.createAndDispatchEvent(node, 'drop', options);
 	},
 	

--- a/src/drag.js
+++ b/src/drag.js
@@ -5,6 +5,9 @@ TODO: This is getting very complicated. We should probably separate the DRAG and
 	into two separate actions
 TODO: It might also be worth giving html5drag and jQuery drag two different code paths, 
 	rather than constantly checking and switching behaviors accordingly mid function
+TODO: Very few of our events actually fill the bubbles and cancelable fields. Any products that 
+	rely on these will not react properly. Is there a way to look up default behaviors for these and 
+	set to those unless somehow overridden?
 */
 
 
@@ -45,7 +48,7 @@ var DragonDrop = {
 		this.currentDataTransferItem = null;
 		this.focusWindow = focusWindow;
 	
-		// This would be a series of events to syntesize a drag operation
+		// A series of events to simulate a drag operation
 		this._mouseOver(fromPoint);
 		this._mouseEnter(fromPoint);
 		this._mouseMove(fromPoint);
@@ -84,13 +87,41 @@ var DragonDrop = {
 	
 	
 
-	_dragStart: function(node, options){ this.createAndDispatchEvent(node, 'dragstart', options); },
-	_drag: function(node, options){ this.createAndDispatchEvent(node, 'drag', options); },
-	_dragEnter: function(node, options){ this.createAndDispatchEvent(node, 'dragenter', options); },
-	_dragOver: function(node, options){ this.createAndDispatchEvent(node, 'dragover', options); },
-	_dragLeave: function(node, options){ this.createAndDispatchEvent(node, 'dragleave', options); },
-	_drop: function(node, options){ this.createAndDispatchEvent(node, 'drop', options); },
-	_dragEnd: function(node, options){ this.createAndDispatchEvent(node, 'dragend', options); },
+	_dragStart: function(node){
+		var options = { bubbles:false, cancelable:false };
+		this.createAndDispatchEvent(node, 'dragstart', options);
+	},
+		
+	_drag: function(node){
+		var options = { bubbles:true, cancelable:true };
+		this.createAndDispatchEvent(node, 'drag', options);
+	},
+	
+	_dragEnter: function(node){ 
+		var options = { bubbles:true, cancelable:true };
+		this.createAndDispatchEvent(node, 'dragenter', options);
+	},
+	
+	_dragOver: function(node){
+		var options = { bubbles:true, cancelable:true };
+		this.createAndDispatchEvent(node, 'dragover', options);
+	},
+	
+	_dragLeave: function(node){
+		var options = { bubbles:true, cancelable:false };
+		this.createAndDispatchEvent(node, 'dragleave', options);
+	},
+	
+	_drop: function(node){
+		var options = { bubbles:false, cancelable:true, buttons:2 };
+		debugger;
+		this.createAndDispatchEvent(node, 'drop', options);
+	},
+	
+	_dragEnd: function(node){
+		var options = { bubbles:true, cancelable:false };
+		this.createAndDispatchEvent(node, 'dragend', options);
+	},
 
 	_mouseDown: function(node, options){ this.createAndDispatchEvent(node, 'mousedown', options); },
 	_mouseMove: function(node, options){ this.createAndDispatchEvent(node, 'mousemove', options); },

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -121,14 +121,16 @@ h.extend(syn.create, {
 				event;
 			if (doc.createEvent) {
 				try {
-					event = doc.createEvent('MouseEvents');
-					event.initMouseEvent(type, defaults.bubbles, defaults.cancelable,
-						defaults.view, defaults.detail,
-						defaults.screenX, defaults.screenY,
-						defaults.clientX, defaults.clientY,
-						defaults.ctrlKey, defaults.altKey,
-						defaults.shiftKey, defaults.metaKey,
-						defaults.button, defaults.relatedTarget);
+					defaults.view = doc.defaultView;
+					//event = doc.createEvent('MouseEvents');
+					event = new MouseEvent(type, defaults);
+					//event.initMouseEvent(type, defaults.bubbles, defaults.cancelable,
+					//	defaults.view, defaults.detail,
+					//	defaults.screenX, defaults.screenY,
+					//	defaults.clientX, defaults.clientY,
+					//	defaults.ctrlKey, defaults.altKey,
+					//	defaults.shiftKey, defaults.metaKey,
+					//	defaults.button, defaults.relatedTarget);
 				} catch (e) {
 					event = h.createBasicStandardEvent(type, defaults, doc);
 				}

--- a/src/mouse.js
+++ b/src/mouse.js
@@ -122,15 +122,22 @@ h.extend(syn.create, {
 			if (doc.createEvent) {
 				try {
 					defaults.view = doc.defaultView;
-					//event = doc.createEvent('MouseEvents');
-					event = new MouseEvent(type, defaults);
-					//event.initMouseEvent(type, defaults.bubbles, defaults.cancelable,
-					//	defaults.view, defaults.detail,
-					//	defaults.screenX, defaults.screenY,
-					//	defaults.clientX, defaults.clientY,
-					//	defaults.ctrlKey, defaults.altKey,
-					//	defaults.shiftKey, defaults.metaKey,
-					//	defaults.button, defaults.relatedTarget);
+					
+					/* TODO: Eventually replace doc.createEvent / initMouseEvent down below (its deprecated )
+						https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent
+						
+						Replace it with this:
+						event = new MouseEvent(type, defaults);
+					*/
+
+					event = doc.createEvent('MouseEvents');
+					event.initMouseEvent(type, defaults.bubbles, defaults.cancelable,
+						defaults.view, defaults.detail,
+						defaults.screenX, defaults.screenY,
+						defaults.clientX, defaults.clientY,
+						defaults.ctrlKey, defaults.altKey,
+						defaults.shiftKey, defaults.metaKey,
+						defaults.button, defaults.relatedTarget);
 				} catch (e) {
 					event = h.createBasicStandardEvent(type, defaults, doc);
 				}

--- a/test/drag_test_basic.js
+++ b/test/drag_test_basic.js
@@ -33,6 +33,8 @@ QUnit.test("Drag Item Upward HTML5", 2, function () {
 
 });
 
+
+
 QUnit.test("Drag Item Downward jQuery", 1, function () {
 	stop();
 
@@ -57,6 +59,30 @@ QUnit.test("Drag Item Downward jQuery", 1, function () {
 
 	testFrame.height = 160;
 	testFrame.src = 'testpages/jquery_dragdrop.html';
+
+});
+
+
+QUnit.test("Drag Regressions 1 - cancel and bubble", 1, function () {
+	stop();
+
+	var testFrame = document.getElementById('pageUnderTest');
+	
+	testFrame.addEventListener('load',  function loadListener(){
+		testFrame.removeEventListener('load', loadListener);	
+		var pageUnderTest = document.getElementById('pageUnderTest').contentDocument.querySelector('body');
+		var draggable = pageUnderTest.querySelector('#outer');
+		var target = pageUnderTest.querySelector('#div1');
+			
+		syn.drag(draggable, {to: target}, function () {
+			
+			ok(true , "Dragged element expected to exist in node: #cell_a2.");		
+			start();
+		});
+	});
+
+	testFrame.height = 350;
+	testFrame.src = 'testpages/regressions_drag.html';
 
 });
 

--- a/test/drag_test_basic.js
+++ b/test/drag_test_basic.js
@@ -63,6 +63,13 @@ QUnit.test("Drag Item Downward jQuery", 1, function () {
 });
 
 
+/*
+	TODO: This test is incomplete. If you run it, you should see the "inner" element dragged into the receptive
+	box above. However, the word "inner" should become "outer" since that is the drag element.
+	
+	My theory is that we are sending the final drag events by page offset rather than dragdrop target, and that
+	it is "hitting" the element being dragged because we are over the dragdrop target at the time of the drop.
+*/
 QUnit.test("Drag Regressions 1 - cancel and bubble", 1, function () {
 	stop();
 

--- a/test/testpages/regressions_drag.html
+++ b/test/testpages/regressions_drag.html
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+	<title>Test to ensure there are no regressions in DragDrop</title>
+	<script>
+
+	var data;
+	
+	
+		function dragover_handler(ev) {
+            ev.preventDefault();
+            // Set the dropEffect to move
+            ev.dataTransfer.dropEffect = "move"
+		}
+
+		function dragstart_handler(ev) {	
+			ev.dataTransfer.setData("text/plain", ev.target.id);
+			ev.dropEffect = "move";
+		}
+
+		function drop_handler(ev) {
+			ev.preventDefault();
+
+			console.log(ev);
+			
+			data = ev.dataTransfer.getData("text/plain");
+			let divElement = document.createElement("div");
+			divElement.textContent = data;
+			ev.target.appendChild(divElement);
+		}
+		
+    </script>
+</head>
+
+<body>
+
+<div id="div1" ondrop="drop_handler(event)" ondragover="dragover_handler(event)" style="
+height: 100px;
+width: 100px;
+border-style: solid;
+border-width: 1px;
+"></div>
+
+<div id="div2" style="
+height: 50px;
+width: 100px;
+border-style: solid;
+border-width: 1px;
+margin-top: 20px;
+">
+
+
+<span id="outer" draggable="true" ondragstart="dragstart_handler(event)"> 
+	<span id="inner">inner</span>
+</span>
+
+
+</div>
+</body>
+
+
+</html>


### PR DESCRIPTION
The cancelable and bubbles events are not set in the drag events generated by HTML5 drag drop.

This is a little weird because they are set by default in mouse.js, which means that they are falling through as page events rather than mouse events.

This is something that I will be looking-into shortly, but in the meantime I'd like this to be fixed on tip.