### PR TITLE
Fix issue 198 - "[escape]" must not type "escape"

### DIFF
--- a/src/key.js
+++ b/src/key.js
@@ -568,6 +568,8 @@ h.extend(syn.key, {
 				syn.trigger(this, "click", {});
 			}
 		},
+		'escape': function () {
+		},
 		
 		// Gets all focusable elements.  If the element (this)
 		// doesn't have a tabindex, finds the next element after.


### PR DESCRIPTION
fix #198

this PR fixes `window.syn.type(el, '[escape]')`

previously `"escape"` text was appended to the input, newly only the escape key is pressed, but no text is typed